### PR TITLE
[WIP] Avoid side effects not modifying wrapped component

### DIFF
--- a/react-motions/src/withInfinite.js
+++ b/react-motions/src/withInfinite.js
@@ -1,10 +1,24 @@
 import React from 'react'
 
-function withInfinite(Component) {
-  Component.props.style['WebkitAnimationIterationCount'] = "infinite"
-  Component.props.style['animationIterationCount'] = "infinite"
+const withInfinite  = (Component) => class extends Component {
+  static displayName = `WithInfinite(${
+    Component.displayName || Component.name
+  })`;
 
-  return Component
+  render() {
+    return (
+      const style = {
+        ...this.props.style,
+        WebkitAnimationIterationCount: 'infinite',
+        animationIterationCount: 'infinite',
+      }
+
+      <Component
+        { ...this.props }
+        style={style}
+      />
+    )
+  }
 }
 
 export default withInfinite


### PR DESCRIPTION
I'm switching `withInfinite` from a function to a class component so that we can avoid modifying the original `Component`, which can cause side effects.

It is incomplete because I couldn't `yarn build` it because of the `static` syntax on line `4`.

@raphamorim First question is, do you think it is a valid change?
Then how can we enable `static`?